### PR TITLE
Add librarian-puppet to the Gemfile

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -9,6 +9,7 @@ gem 'puppetlabs_spec_helper', '~> 2.3.2'
 gem 'puppet-syntax', '~> 2.4.1'
 
 group :functional_tests do
+  gem 'librarian-puppet'
   gem 'test-kitchen'
   gem 'kitchen-docker'
   gem 'kitchen-inspec'


### PR DESCRIPTION
This is used by test-kitchen to pull puppet modules
listed in the Puppetfile in to the machine used for the tests.